### PR TITLE
Update ex_1706.cpp

### DIFF
--- a/Chapter17/exercises/17.06/ex_1706.cpp
+++ b/Chapter17/exercises/17.06/ex_1706.cpp
@@ -49,29 +49,46 @@ int main(int argc, const char* argv[]) {
     std::string fName;
     std::string lName;
 
+    // handling files with one record
+    inTransaction >> transAccountNum >> transDollarAmount;
+    inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
+    
     // process changes
     while (!inOldMaster.eof() && !inTransaction.eof()) {
-        inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
-        // ensure mastAccountNum !exceed transAccountNum
         if (transAccountNum < mastAccountNum)
-            inTransaction >> transAccountNum >> transDollarAmount;
-
-        // update total on account number match
-        if (mastAccountNum == transAccountNum) {
-            mastDollarAmount += transDollarAmount;
-        } else if (((mastAccountNum > transAccountNum) &&
-                    !inTransaction.eof()) ||
-                   inOldMaster.eof()) {
+        {
             std::cout << "Unmatched transaction record for account number: "
                       << transAccountNum << std::endl;
+            inTransaction >> transAccountNum >> transDollarAmount;
         }
-
-        // only update if not at eof
-        // ensures transAccountNum's > the last record in the old master file
-        // are properly handled logged.
-        if (!inOldMaster.eof())
+        else if (transAccountNum == mastAccountNum)
+        {
+            mastDollarAmount += transDollarAmount;
             outNewMaster << mastAccountNum << " " << fName << " " << lName
                          << " " << mastDollarAmount << std::endl;
+            inTransaction >> transAccountNum >> transDollarAmount;
+            inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
+        }
+        else if (transAccountNum > mastAccountNum)
+        {
+            outNewMaster << mastAccountNum << " " << fName << " " << lName
+                         << " " << mastDollarAmount << std::endl;
+            inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
+        }
+    }
+    // if trans.dat reachs to end of file befor oldmast.dat
+    while ( !inOldMaster.eof() )
+    {
+        outNewMaster << mastAccountNum << " " << fName << " " << lName
+                     << " " << mastDollarAmount << std::endl;
+        inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
+    }
+    // if oldmast.dat reachs to end of file befor trans.dat
+    while ( !inTransaction.eof() )
+    {
+        std::cout << "Unmatched transaction record for account number: "
+                  << transAccountNum << std::endl;
+            inTransaction >> transAccountNum >> transDollarAmount;
     }
 
     return 0;

--- a/Chapter17/exercises/17.06/ex_1706.cpp
+++ b/Chapter17/exercises/17.06/ex_1706.cpp
@@ -55,37 +55,30 @@ int main(int argc, const char* argv[]) {
     
     // process changes
     while (!inOldMaster.eof() && !inTransaction.eof()) {
-        if (transAccountNum < mastAccountNum)
-        {
+        if (transAccountNum < mastAccountNum) {
             std::cout << "Unmatched transaction record for account number: "
                       << transAccountNum << std::endl;
             inTransaction >> transAccountNum >> transDollarAmount;
-        }
-        else if (transAccountNum == mastAccountNum)
-        {
+        } else if (transAccountNum == mastAccountNum) {
             mastDollarAmount += transDollarAmount;
             outNewMaster << mastAccountNum << " " << fName << " " << lName
                          << " " << mastDollarAmount << std::endl;
             inTransaction >> transAccountNum >> transDollarAmount;
             inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
-        }
-        else if (transAccountNum > mastAccountNum)
-        {
+        } else if (transAccountNum > mastAccountNum) {
             outNewMaster << mastAccountNum << " " << fName << " " << lName
                          << " " << mastDollarAmount << std::endl;
             inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
         }
     }
-    // if trans.dat reachs to end of file befor oldmast.dat
-    while ( !inOldMaster.eof() )
-    {
+    // if trans.dat reachs to end of file before oldmast.dat
+    while ( !inOldMaster.eof() ) {
         outNewMaster << mastAccountNum << " " << fName << " " << lName
                      << " " << mastDollarAmount << std::endl;
         inOldMaster >> mastAccountNum >> fName >> lName >> mastDollarAmount;
     }
-    // if oldmast.dat reachs to end of file befor trans.dat
-    while ( !inTransaction.eof() )
-    {
+    // if oldmast.dat reachs to end of file before trans.dat
+    while ( !inTransaction.eof() ) {
         std::cout << "Unmatched transaction record for account number: "
                   << transAccountNum << std::endl;
             inTransaction >> transAccountNum >> transDollarAmount;


### PR DESCRIPTION
There is two problem with code:
1.  If the EOF is reached in `trans.dat` file before `oldmast.dat` , **_while_** condition becomes false so leaves records in `oldmast.dat` unprocessed and doesn't write those records in `newmast.dat` 

2. When there is a transaction record but no corresponding master record, your code doesn't output message "Unmatched transaction record for account number ..." correctly.
here you can examine it with following test data:

oldmast.dat:
100 name1 family1 348.17
300 name2 family2 27.19
400 name3 family3 25.23
500 name4 family4 1.23
700 name5 family5 -14.22
900 name6 family6 16.21
1100 name7 family7 20
1300 name8 family8 31
1500 name9 family9 10

trans.dat:
300 7
500 6
800 3
1000 5

Thanks!
